### PR TITLE
Automatically update notebook headers

### DIFF
--- a/Welcome.ipynb
+++ b/Welcome.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": []
+    "tags": [
+     "cal.header"
+    ]
    },
    "source": [
     "<link rel=\"stylesheet\" href=\"https://use.typekit.net/dvn1law.css\">\n",
@@ -19,15 +21,19 @@
     "    <div style=\"margin-bottom: auto; margin-top: auto; margin-right: auto; padding-right: 15px;\">\n",
     "        <div style=\"margin: 0; padding-top: 0.2rem; padding-bottom: 3.3rem; letter-spacing: 0.15rem; color: #a6ce37; font-weight: bold; font-size: 3rem; font: futura-pt-bold\"> CEOS Analytics Lab</div>\n",
     "        <div style=\"margin: 0; color: #469ab9; font-weight: bold; font-size: 1.5rem;\">Welcome to the CEOS Analytics Lab!</div>\n",
-    "        <div style=\"margin: 0; padding-bottom: 0.2rem; color: #474c38; font-size: 1.25rem;\">Introduction and Overview| <span style=\"color: #3b6d48; font-weight: bold;\">The Open Data Cube and Available Products</span></div>\n",
+    "        <div style=\"margin: 0; padding-bottom: 0.2rem; color: #474c38; font-size: 1.25rem;\"><span>Introduction and Overview</span><span>| </span><span style=\"color: #3b6d48; font-weight: bold;\">The Open Data Cube and Available Products</span></div>\n",
     "        <hr style=\"border: 1px solid #474c38;\">\n",
     "    </div>\n",
     "    <div style=\"margin-top: auto; margin-bottom: auto; margin-left: auto; padding-left: 15px;\">\n",
-    "        <div><img style=\"vertical-align: middle; padding: 0.5rem; width: 300px; height: auto;\" src=\"https://ceos.org/document_management/Communications/CEOS-Logos/CEOS-Logo-Version-1_Green-No-Text_2021.png\" /></div>\n",
+    "        <div><img style=\"vertical-align: middle; padding: 0.5rem; width: 300px; height: auto;\" src=\"https://ceos.org/document_management/Communications/CEOS-Logos/CEOS_logo_colour_no_text-small.png\" /></div>\n",
     "    </div>\n",
-    "</div>\n",
-    "\n",
-    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### What is the CEOS Analytics Lab?\n",
     "The CEOS Analytics Lab (CAL) provides a scalable analysis environment built to analyze years of Earth observation (EO) data. CAL is powered by CSIRO's EASI platform and is built with the Open Data Cube.\n",
     "\n",
@@ -536,6 +542,10 @@
   }
  ],
  "metadata": {
+  "cal": {
+   "category": "Introduction and Overview",
+   "title": "The Open Data Cube and Available Products"
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -551,7 +561,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {

--- a/assets/templates/header.html
+++ b/assets/templates/header.html
@@ -1,0 +1,20 @@
+<link rel="stylesheet" href="https://use.typekit.net/dvn1law.css">
+<style>        
+@font-face {
+font-family:"futura-pt-bold";
+src:url("https://use.typekit.net/af/053fc9/00000000000000003b9af1e4/27/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff2"),url("https://use.typekit.net/af/053fc9/00000000000000003b9af1e4/27/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("woff"),url("https://use.typekit.net/af/053fc9/00000000000000003b9af1e4/27/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3") format("opentype");
+font-display:auto;font-style:normal;font-weight:700;font-stretch:normal;
+}
+</style>
+<div style="display: flex; margin: 0px; padding-top: 1.5rem; padding-bottom: 1.5rem; font-family: futura-pt, 'Tahoma', 'Segoe UI', Geneva, Verdana, sans-serif;">
+    <span style="margin-right: 15px; padding-right: 2rem; background-color: #3b6d48;"></span>
+    <div style="margin-bottom: auto; margin-top: auto; margin-right: auto; padding-right: 15px;">
+        <div style="margin: 0; padding-top: 0.2rem; padding-bottom: 3.3rem; letter-spacing: 0.15rem; color: #a6ce37; font-weight: bold; font-size: 3rem; font: futura-pt-bold"> CEOS Analytics Lab</div>
+        <div style="margin: 0; color: #469ab9; font-weight: bold; font-size: 1.5rem;">Welcome to the CEOS Analytics Lab!</div>
+        <div style="margin: 0; padding-bottom: 0.2rem; color: #474c38; font-size: 1.25rem;"><span>{{ category }}</span><span>| </span><span style="color: #3b6d48; font-weight: bold;">{{ title }}</span></div>
+        <hr style="border: 1px solid #474c38;">
+    </div>
+    <div style="margin-top: auto; margin-bottom: auto; margin-left: auto; padding-left: 15px;">
+        <div><img style="vertical-align: middle; padding: 0.5rem; width: 300px; height: auto;" src="https://ceos.org/document_management/Communications/CEOS-Logos/CEOS_logo_colour_no_text-small.png" /></div>
+    </div>
+</div>

--- a/bin/updateheaders.py
+++ b/bin/updateheaders.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import os
+import nbformat as nbf
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from glob import glob
+
+# A notebook is a CAL notebook if it defines CAL metadata
+def is_cal_notebook(path):
+    notebook = nbf.read(path, nbf.NO_CONVERT)
+    return notebook.get('metadata', {}).hasattr('cal')
+
+# The header cell must carry a cal.metadata tag
+def get_or_create_header(notebook):
+    header_cell = None
+    
+    for cell in notebook.cells:
+        if 'cal.header' in cell.get('metadata', {}).get('tags', []):
+            header_cell = cell
+            
+    if header_cell is None:
+        header_cell = nbf.v4.new_markdown_cell(metadata={'tags': ['cal.header']})
+        notebook.cells.insert(0, header_cell)
+    
+    return header_cell
+
+if __name__ == '__main__':
+    home = os.path.expanduser('~')
+    
+    # Initialize jinja2
+    env = Environment(
+        loader=FileSystemLoader(f"{home}/cal-notebooks/assets/templates"),
+        autoescape=select_autoescape()
+    )
+    
+    # Collect a list of all CAL notebooks in the repository
+    notebook_paths = filter(is_cal_notebook, glob(f"{home}/cal-notebooks/**/*.ipynb", recursive=True))
+    
+    # Update all the headers
+    for path in notebook_paths:
+        cal_notebook = nbf.read(path, nbf.NO_CONVERT)
+
+        cal_metadata = cal_notebook.get('metadata', {}).get('cal', {})
+
+        template = env.get_template('header.html')
+        header = template.render(**cal_metadata)
+
+        header_cell = get_or_create_header(cal_notebook)
+        header_cell['source'] = header
+
+        nbf.write(cal_notebook, path)


### PR DESCRIPTION
# Summary
Defines a standard header template, custom notebook metadata for providing header values, a tag for marking a cell as a header, and a script to automate the update process.

# Details
## Custom metadata
```json
"cal": {
    "category": "Introduction and Overview",
    "title": "The Open Data Cube and Available Products"
}
```
The `cal` key identifies the notebook as a CAL notebook subject to automatic header updates and defines a namespace for sub-keys. The keys in the `cal` namespace define the values of the variables defined by the header template. Other notebooks are ignored.

## Header template

The header template is a standalone HTML document which defines `jinja2` template variables. The `jinja2` package is part of the standard CAL environment.

## Update script

The update script recursively searches the entire repository for CAL notebooks and updates (or adds) the CAL header to the notebook using the supplied template variable values. Existing header cells are identified by the presence of the `cal.header` tag. 
The script makes no assumptions about the template variables, so the template and metadata schema can be updated without modifying the script.

## Environment setup
```bash
chmod +x ~/cal-notebooks/bin/updateheaders.py

# .bashrc
alias updateheaders=~/cal-notebooks/bin/updateheaders.py
```